### PR TITLE
Ignore unrecognized state items (e.g. indices, lengths)

### DIFF
--- a/include/noarr/structures/base/state.hpp
+++ b/include/noarr/structures/base/state.hpp
@@ -101,9 +101,14 @@ struct state : contain<typename StateItems::value_type...> {
 		return base::template get<index_of<Tag>.value>();
 	}
 
-	template<class... NewStateItems>
-	constexpr state<NewStateItems...> restrict(helpers::state_items_pack<NewStateItems...> = {}) const noexcept {
-		return state<NewStateItems...>(get<typename NewStateItems::tag>()...);
+	template<class... KeptStateItems>
+	constexpr state<KeptStateItems...> restrict(helpers::state_items_pack<KeptStateItems...> = {}) const noexcept {
+		return state<KeptStateItems...>(get<typename KeptStateItems::tag>()...);
+	}
+
+	template<class... NewTags, class... NewValueTypes, class... KeptStateItems>
+	constexpr state<KeptStateItems..., state_item<NewTags, NewValueTypes>...> restrict_add(helpers::state_items_pack<KeptStateItems...>, NewValueTypes... new_values) const noexcept {
+		return state<KeptStateItems..., state_item<NewTags, NewValueTypes>...>(get<typename KeptStateItems::tag>()..., new_values...);
 	}
 
 	template<class... Tags>
@@ -113,7 +118,7 @@ struct state : contain<typename StateItems::value_type...> {
 
 	template<class... Tags, class... ValueTypes>
 	constexpr auto with(ValueTypes... values) const noexcept {
-		return state<StateItems..., state_item<Tags, ValueTypes>...>(get<typename StateItems::tag>()..., values...);
+		return restrict_add<Tags...>(typename helpers::state_remove_items<helpers::state_items_pack<StateItems...>, Tags...>::result(), values...);
 	}
 
 	template<class... NewStateItems>

--- a/include/noarr/structures/base/structs_common.hpp
+++ b/include/noarr/structures/base/structs_common.hpp
@@ -31,7 +31,6 @@ struct dim_param;
 template<class StructInner, class StructOuter, class State>
 constexpr auto offset_of(StructOuter structure, State state) noexcept {
 	if constexpr(std::is_same_v<StructInner, StructOuter>) {
-		// TODO check that state only contains relevant lengths
 		return constexpr_arithmetic::make_const<0>();
 	} else {
 		return structure.template strict_offset_of<StructInner>(state);

--- a/include/noarr/structures/extra/funcs.hpp
+++ b/include/noarr/structures/extra/funcs.hpp
@@ -40,7 +40,7 @@ constexpr auto offset(Idxs... idxs) noexcept { return offset<SubStruct>(empty_st
 
 template<class State>
 constexpr auto offset(State state) noexcept { return [state](auto structure) constexpr noexcept {
-	using type = unchecked_scalar_t<decltype(structure), State>;
+	using type = scalar_t<decltype(structure), State>;
 	return offset_of<scalar<type>>(structure, state);
 }; }
 
@@ -77,7 +77,7 @@ constexpr auto sub_ptr(const volatile void *ptr, std::size_t off) noexcept { ret
  */
 template<class State, class CvVoid>
 constexpr auto get_at(CvVoid *ptr, State state) noexcept { return [ptr, state](auto structure) constexpr noexcept -> decltype(auto) {
-	using type = unchecked_scalar_t<decltype(structure), State>;
+	using type = scalar_t<decltype(structure), State>;
 	return *helpers::sub_ptr<type>(ptr, offset_of<scalar<type>>(structure, state));
 }; }
 

--- a/include/noarr/structures/extra/shortcuts.hpp
+++ b/include/noarr/structures/extra/shortcuts.hpp
@@ -53,14 +53,14 @@ template<char Dim, class State, class F>
 constexpr auto update_index(State state, F f) {
 	static_assert(State::template contains<index_in<Dim>>, "Requested dimension does not exist. To add a new dimension instead of updating existing one, use .template with<index_in<'...'>>(...)");
 	auto new_index = f(state.template get<index_in<Dim>>());
-	return state.template remove<index_in<Dim>>().template with<index_in<Dim>>(good_index_t<decltype(new_index)>(new_index));
+	return state.template with<index_in<Dim>>(good_index_t<decltype(new_index)>(new_index));
 }
 
 template<char... Dims, class State>
 constexpr auto neighbor(State state, std::enable_if_t<true || Dims, std::ptrdiff_t>... diffs) noexcept {
 	static_assert((... && State::template contains<index_in<Dims>>), "Requested dimension does not exist");
 	static_assert((... && std::is_same_v<state_get_t<State, index_in<Dims>>, std::size_t>), "Cannot shift in a dimension that is not dynamic");
-	return state.template remove<index_in<Dims>...>().template with<index_in<Dims>...>(std::size_t(state.template get<index_in<Dims>>() + diffs)...);
+	return state.template with<index_in<Dims>...>(std::size_t(state.template get<index_in<Dims>>() + diffs)...);
 }
 
 // State to structure

--- a/include/noarr/structures/extra/struct_traits.hpp
+++ b/include/noarr/structures/extra/struct_traits.hpp
@@ -43,21 +43,20 @@ struct is_cube : sig_is_cube<typename T::signature> {};
 
 
 
-template<class T, class State, bool Checked>
+template<class T, class State>
 struct sig_get_scalar;
-template<char Dim, class ArgLength, class RetSig, class State, bool Checked>
-struct sig_get_scalar<function_sig<Dim, ArgLength, RetSig>, State, Checked> {
-	static_assert(State::template contains<index_in<Dim>> || !Checked, "Not all dimensions are fixed");
-	using type = typename sig_get_scalar<RetSig, state_remove_t<State, index_in<Dim>, length_in<Dim>>, Checked>::type;
+template<char Dim, class ArgLength, class RetSig, class State>
+struct sig_get_scalar<function_sig<Dim, ArgLength, RetSig>, State> {
+	using type = typename sig_get_scalar<RetSig, state_remove_t<State, index_in<Dim>, length_in<Dim>>>::type;
 };
-template<char Dim, class... RetSigs, class State, bool Checked>
-struct sig_get_scalar<dep_function_sig<Dim, RetSigs...>, State, Checked> {
-	static_assert(State::template contains<index_in<Dim>>, "Not all dimensions are fixed");
+template<char Dim, class... RetSigs, class State>
+struct sig_get_scalar<dep_function_sig<Dim, RetSigs...>, State> {
+	static_assert(State::template contains<index_in<Dim>>, "Not all tuple dimensions are fixed");
 	static_assert(state_get_t<State, index_in<Dim>>::value || true, "Tuple index must be set statically, wrap it in idx<> (e.g. replace 42 with idx<42>)");
-	using type = typename sig_get_scalar<typename dep_function_sig<Dim, RetSigs...>::template ret_sig<state_get_t<State, index_in<Dim>>::value>, state_remove_t<State, index_in<Dim>, length_in<Dim>>, Checked>::type;
+	using type = typename sig_get_scalar<typename dep_function_sig<Dim, RetSigs...>::template ret_sig<state_get_t<State, index_in<Dim>>::value>, state_remove_t<State, index_in<Dim>, length_in<Dim>>>::type;
 };
-template<class ValueType, class State, bool Checked>
-struct sig_get_scalar<scalar_sig<ValueType>, State, Checked> {
+template<class ValueType, class State>
+struct sig_get_scalar<scalar_sig<ValueType>, State> {
 	using type = ValueType;
 };
 
@@ -67,10 +66,7 @@ struct sig_get_scalar<scalar_sig<ValueType>, State, Checked> {
  * @tparam T: the `scalar<...>`
  */
 template<class T, class State = state<>>
-using scalar_t = typename sig_get_scalar<typename T::signature, State, true>::type;
-
-template<class T, class State = state<>>
-using unchecked_scalar_t = typename sig_get_scalar<typename T::signature, State, false>::type;
+using scalar_t = typename sig_get_scalar<typename T::signature, State>::type;
 
 } // namespace noarr
 

--- a/include/noarr/structures/extra/struct_traits.hpp
+++ b/include/noarr/structures/extra/struct_traits.hpp
@@ -58,7 +58,6 @@ struct sig_get_scalar<dep_function_sig<Dim, RetSigs...>, State, Checked> {
 };
 template<class ValueType, class State, bool Checked>
 struct sig_get_scalar<scalar_sig<ValueType>, State, Checked> {
-	static_assert(State::is_empty || !Checked, "Superfluous parameters passed in the state");
 	using type = ValueType;
 };
 

--- a/include/noarr/structures/extra/traverser.hpp
+++ b/include/noarr/structures/extra/traverser.hpp
@@ -104,16 +104,6 @@ public:
 	constexpr std::size_t length(State state) const noexcept {
 		return base::template get<first_match<QDim>>().template length<QDim>(state);
 	}
-
-	template<class F, class State>
-	static constexpr void single_iter(F f, State state) noexcept {
-		f(state.restrict(helpers::union_filter_accepted_t<Structs, State>())...);
-	}
-
-	template<class State>
-	static constexpr auto restrict_states(State state) noexcept {
-		return std::make_tuple(state.restrict(helpers::union_filter_accepted_t<Structs, State>())...);
-	}
 };
 
 template<class Struct, class Order>
@@ -139,10 +129,6 @@ struct traverser_t : contain<Struct, Order> {
 		auto top_struct = get_struct() ^ get_order();
 		static_assert(for_each_impl<typename decltype(top_struct)::signature>::single_state, "There may be multiple states to traverse - use for_each");
 		return state_at<Struct>(top_struct, empty_state);
-	}
-
-	constexpr auto states() const noexcept {
-		return Struct::restrict_states(state());
 	}
 
 	constexpr auto range() const noexcept; // defined in traverser_iter.hpp
@@ -179,7 +165,7 @@ private:
 		static constexpr bool single_state = true;
 		template<class TopStruct, class F, class State>
 		static constexpr void for_each(TopStruct top_struct, F f, State state) noexcept {
-			Struct::single_iter(f, state_at<Struct>(top_struct, state));
+			f(state_at<Struct>(top_struct, state));
 		}
 	};
 };

--- a/include/noarr/structures/interop/cuda_striped.cuh
+++ b/include/noarr/structures/interop/cuda_striped.cuh
@@ -126,7 +126,7 @@ constexpr auto cuda_striped() noexcept { return cuda_striped_proto<NumStripes, E
 
 
 template<std::size_t NumStripes, std::size_t BankCount, std::size_t BankWidth, class T>
-using cuda_scalar_striped_t = cuda_striped_t<NumStripes, scalar<unchecked_scalar_t<T>>, BankCount, BankWidth, T>;
+using cuda_scalar_striped_t = cuda_striped_t<NumStripes, scalar<scalar_t<T>>, BankCount, BankWidth, T>;
 
 template<std::size_t NumStripes, std::size_t BankCount, std::size_t BankWidth>
 struct cuda_scalar_striped_proto {

--- a/include/noarr/structures/interop/cuda_traverser.cuh
+++ b/include/noarr/structures/interop/cuda_traverser.cuh
@@ -39,7 +39,6 @@ struct cuda_fix_t : contain<T> {
 
 	constexpr T sub_structure() const noexcept { return base::template get<0>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement {
@@ -52,9 +51,7 @@ public:
 
 	template<class State>
 	static __device__ inline auto sub_state(State state) noexcept {
-		static_assert(!State::template contains<index_in<Dim>>, "This dimension is already fixed, it cannot be used from outside");
-		static_assert(!State::template contains<length_in<Dim>>, "This dimension is already fixed, it cannot be used from outside");
-		return state.template with<index_in<Dim>>(CudaDim::idx());
+		return state.template remove<length_in<Dim>>().template with<index_in<Dim>>(CudaDim::idx());
 	}
 
 	template<class State>

--- a/include/noarr/structures/interop/tbb.hpp
+++ b/include/noarr/structures/interop/tbb.hpp
@@ -28,8 +28,8 @@ inline void tbb_reduce(const Traverser &t, const FNeut &f_neut, const FAcc &f_ac
 	if constexpr(OutStruct::signature::template all_accept<top_dim>) {
 		// parallel writes will go to different offsets => out_ptr may be shared
 		tbb::parallel_for(t.range(), [&f_acc, out_ptr](const range_t &subrange) {
-			subrange.for_each([f_acc, out_ptr](auto... states) {
-				f_acc(states..., out_ptr);
+			subrange.for_each([f_acc, out_ptr](auto state) {
+				f_acc(state, out_ptr);
 			});
 		});
 	} else {
@@ -54,8 +54,8 @@ inline void tbb_reduce(const Traverser &t, const FNeut &f_neut, const FAcc &f_ac
 				});
 				local.raw = local_out_ptr;
 			}
-			subrange.for_each([f_acc, local_out_ptr](auto... states) {
-				f_acc(states..., local_out_ptr);
+			subrange.for_each([f_acc, local_out_ptr](auto state) {
+				f_acc(state, local_out_ptr);
 			});
 		});
 		out_ptrs.combine_each([out_struct, out_ptr, &f_join](const private_ptr &local_out_ptr) {

--- a/include/noarr/structures/structs/bcast.hpp
+++ b/include/noarr/structures/structs/bcast.hpp
@@ -40,7 +40,6 @@ struct bcast_t : contain<T> {
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
 			static_assert(State::template contains<length_in<Dim>>, "This length has not been set yet");
-			// TODO check remaining state
 			return state.template get<length_in<Dim>>();
 		} else {
 			return sub_structure().template length<QDim>(state.template remove<index_in<Dim>, length_in<Dim>>());

--- a/include/noarr/structures/structs/layouts.hpp
+++ b/include/noarr/structures/structs/layouts.hpp
@@ -45,7 +45,7 @@ struct tuple : contain<TS...> {
 		static_assert(State::template contains<index_in<Dim>>, "All indices must be set");
 		static_assert(state_get_t<State, index_in<Dim>>::value || true, "Tuple index must be set statically, wrap it in idx<> (e.g. replace 42 with idx<42>)");
 		constexpr std::size_t index = state_get_t<State, index_in<Dim>>::value;
-		auto sub_state = state.template remove<index_in<Dim>>(); // TODO remove all indices for size_inner
+		auto sub_state = state.template remove<index_in<Dim>>();
 		return size_inner(std::make_index_sequence<index>(), sub_state) + offset_of<Sub>(sub_structure<index>(), sub_state);
 	}
 
@@ -54,7 +54,6 @@ struct tuple : contain<TS...> {
 		static_assert(!State::template contains<length_in<Dim>>, "Cannot set tuple length");
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
-			// TODO check remaining state
 			return constexpr_arithmetic::make_const<sizeof...(TS)>();
 		} else {
 			static_assert(State::template contains<index_in<Dim>>, "Tuple indices must be set");
@@ -132,7 +131,6 @@ struct array : contain<T> {
 		static_assert(!State::template contains<length_in<Dim>>, "Cannot set array length");
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
-			// TODO check remaining state
 			return constexpr_arithmetic::make_const<L>();
 		} else {
 			return sub_structure().template length<QDim>(state.template remove<index_in<Dim>>());
@@ -197,7 +195,6 @@ struct vector : contain<T> {
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
 			static_assert(State::template contains<length_in<Dim>>, "This length has not been set yet");
-			// TODO check remaining state
 			return state.template get<length_in<Dim>>();
 		} else {
 			return sub_structure().template length<QDim>(state.template remove<index_in<Dim>, length_in<Dim>>());

--- a/include/noarr/structures/structs/scalar.hpp
+++ b/include/noarr/structures/structs/scalar.hpp
@@ -26,7 +26,6 @@ struct scalar : contain<> {
 
 	template<class State>
 	constexpr auto size(State) const noexcept {
-		static_assert(State::is_empty, "Unused items in state");
 		return constexpr_arithmetic::make_const<sizeof(T)>();
 	}
 

--- a/include/noarr/structures/structs/setters.hpp
+++ b/include/noarr/structures/structs/setters.hpp
@@ -23,7 +23,6 @@ struct fix_t : contain<T, IdxT> {
 	constexpr T sub_structure() const noexcept { return base::template get<0>(); }
 	constexpr IdxT idx() const noexcept { return base::template get<1>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement;
@@ -43,9 +42,7 @@ public:
 
 	template<class State>
 	constexpr auto sub_state(State state) const noexcept {
-		static_assert(!State::template contains<index_in<Dim>>, "This dimension is already fixed, it cannot be used from outside");
-		static_assert(!State::template contains<length_in<Dim>>, "This dimension is already fixed, it cannot be used from outside");
-		return state.template with<index_in<Dim>>(idx());
+		return state.template remove<length_in<Dim>>().template with<index_in<Dim>>(idx());
 	}
 
 	template<class State>
@@ -107,7 +104,6 @@ struct set_length_t : contain<T, LenT> {
 	constexpr T sub_structure() const noexcept { return base::template get<0>(); }
 	constexpr LenT len() const noexcept { return base::template get<1>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement;

--- a/include/noarr/structures/structs/slice.hpp
+++ b/include/noarr/structures/structs/slice.hpp
@@ -169,7 +169,7 @@ public:
 	constexpr auto sub_state(State state) const noexcept {
 		using namespace constexpr_arithmetic;
 		if constexpr(State::template contains<index_in<Dim>>)
-			return state.template remove<index_in<Dim>>().template with<index_in<Dim>>(state.template get<index_in<Dim>>() + start());
+			return state.template with<index_in<Dim>>(state.template get<index_in<Dim>>() + start());
 		else
 			return state;
 	}
@@ -264,7 +264,7 @@ public:
 	constexpr auto sub_state(State state) const noexcept {
 		using namespace constexpr_arithmetic;
 		if constexpr(State::template contains<index_in<Dim>>)
-			return state.template remove<index_in<Dim>>().template with<index_in<Dim>>(state.template get<index_in<Dim>>() * stride() + start());
+			return state.template with<index_in<Dim>>(state.template get<index_in<Dim>>() * stride() + start());
 		else
 			return state;
 	}

--- a/include/noarr/structures/structs/slice.hpp
+++ b/include/noarr/structures/structs/slice.hpp
@@ -23,7 +23,6 @@ struct shift_t : contain<T, StartT> {
 	constexpr T sub_structure() const noexcept { return base::template get<0>(); }
 	constexpr StartT start() const noexcept { return base::template get<1>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement;
@@ -86,7 +85,6 @@ public:
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
 			if constexpr(State::template contains<length_in<Dim>>) {
-				// TODO check remaining state
 				return state.template get<length_in<Dim>>();
 			} else {
 				return sub_structure().template length<Dim>(state.template remove<index_in<Dim>, length_in<Dim>>()) - start();
@@ -141,7 +139,6 @@ struct slice_t : contain<T, StartT, LenT> {
 	constexpr StartT start() const noexcept { return base::template get<1>(); }
 	constexpr LenT len() const noexcept { return base::template get<2>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement;
@@ -191,7 +188,6 @@ public:
 		static_assert(!State::template contains<length_in<Dim>>, "Cannot set slice length");
 		if constexpr(QDim == Dim) {
 			static_assert(!State::template contains<index_in<Dim>>, "Index already set");
-			// TODO check remaining state
 			return len();
 		} else {
 			return sub_structure().template length<QDim>(sub_state(state));
@@ -235,7 +231,6 @@ struct step_t : contain<T, StartT, StrideT> {
 	constexpr StartT start() const noexcept { return base::template get<1>(); }
 	constexpr StrideT stride() const noexcept { return base::template get<2>(); }
 
-	static_assert(T::signature::template all_accept<Dim>, "The structure does not have a dimension of this name");
 private:
 	template<class Original>
 	struct dim_replacement;

--- a/include/noarr/structures/structs/views.hpp
+++ b/include/noarr/structures/structs/views.hpp
@@ -322,7 +322,6 @@ private:
 	struct assertion<std::integer_sequence<char, ExternalDims...>, std::integer_sequence<char, InternalDims...>> {
 		template<char Dim>
 		static constexpr bool is_free = (!T::signature::template any_accept<Dim> || ... || (Dim == InternalDims)); // never used || used but renamed
-		static_assert((... && T::signature::template any_accept<InternalDims>), "The structure does not have a dimension of a specified name. Usage: rename<Old1, New1, Old2, New2, ...>()");
 		static_assert((... && is_free<ExternalDims>), "The structure already has a dimension of a specified name. Usage: rename<Old1, New1, Old2, New2, ...>()");
 		// Note: in case a dimension is renamed to itself, is_free returns true. This is necessary to make the above assertion pass.
 		// The `rename_uniquity<external>` check already ensures that if a dimension is renamed to itself, no other dimension is renamed to its name.

--- a/include/noarr/structures/structs/zcurve.hpp
+++ b/include/noarr/structures/structs/zcurve.hpp
@@ -134,7 +134,6 @@ struct merge_zcurve_t : contain<T> {
 	static_assert(sizeof...(Dims), "No dimensions to merge");
 	static_assert(sizeof...(Dims) <= 8*sizeof(std::size_t), "Too many dimensions to merge");
 	static_assert(helpers::zc_uniquity<Dims...>::value, "Cannot merge a dimension with itself");
-	static_assert((... && T::signature::template all_accept<Dims>), "The structure does not have a dimension of this name");
 	static_assert((... || (Dim == Dims)) || !T::signature::template any_accept<Dim>, "Dimension of this name already exists");
 private:
 	template<int Remaining, class ArgLenAcc>
@@ -171,11 +170,7 @@ public:
 	template<class State, std::size_t... DimsI>
 	constexpr auto sub_state(State state, std::index_sequence<DimsI...>) const noexcept {
 		static_assert(!State::template contains<length_in<Dim>>, "Cannot set z-curve length");
-		/* TODO if constexpr(Dims != Dim) {
-			static_assert(!State::template contains<index_in<Dims>>, "Index in this dimension is overriden by a substructure");
-			static_assert(!State::template contains<length_in<Dims>>, "Index in this dimension is overriden by a substructure");
-		}...*/
-		auto clean_state = state.template remove<index_in<Dim>>();
+		auto clean_state = state.template remove<index_in<Dim>, index_in<Dims>..., length_in<Dims>...>();
 		if constexpr(State::template contains<index_in<Dim>>) {
 			auto index = state.template get<index_in<Dim>>();
 			auto index_general = index >> SpecialLevel*sizeof...(Dims);

--- a/tests/traverser_test.cpp
+++ b/tests/traverser_test.cpp
@@ -44,35 +44,23 @@ TEST_CASE("Traverser trivial", "[traverser]") {
 
 	int i = 0;
 
-	traverser(a, b, c).for_each([&i](auto sa, auto sb, auto sc){
-		static_assert( decltype(sa)::template contains<index_in<'x'>>);
-		static_assert( decltype(sa)::template contains<index_in<'y'>>);
-		static_assert(!decltype(sa)::template contains<index_in<'z'>>);
+	traverser(a, b, c).for_each([&i](auto s){
+		static_assert(decltype(s)::template contains<index_in<'x'>>);
+		static_assert(decltype(s)::template contains<index_in<'y'>>);
+		static_assert(decltype(s)::template contains<index_in<'z'>>);
 
-		static_assert(!decltype(sb)::template contains<index_in<'x'>>);
-		static_assert( decltype(sb)::template contains<index_in<'y'>>);
-		static_assert( decltype(sb)::template contains<index_in<'z'>>);
+		REQUIRE(s.template get<index_in<'x'>>() < 20);
+		REQUIRE(s.template get<index_in<'y'>>() < 30);
+		REQUIRE(s.template get<index_in<'z'>>() < 40);
 
-		static_assert( decltype(sc)::template contains<index_in<'x'>>);
-		static_assert(!decltype(sc)::template contains<index_in<'y'>>);
-		static_assert( decltype(sc)::template contains<index_in<'z'>>);
-
-		REQUIRE(sa.template get<index_in<'x'>>() == sc.template get<index_in<'x'>>());
-		REQUIRE(sa.template get<index_in<'y'>>() == sb.template get<index_in<'y'>>());
-		REQUIRE(sb.template get<index_in<'z'>>() == sc.template get<index_in<'z'>>());
-
-		REQUIRE(sa.template get<index_in<'x'>>() < 20);
-		REQUIRE(sb.template get<index_in<'y'>>() < 30);
-		REQUIRE(sc.template get<index_in<'z'>>() < 40);
-
-		REQUIRE(get_index<'x'>(sa) == sa.template get<index_in<'x'>>());
-		REQUIRE(get_index<'y'>(sb) == sb.template get<index_in<'y'>>());
-		REQUIRE(get_index<'z'>(sc) == sc.template get<index_in<'z'>>());
+		REQUIRE(get_index<'x'>(s) == s.template get<index_in<'x'>>());
+		REQUIRE(get_index<'y'>(s) == s.template get<index_in<'y'>>());
+		REQUIRE(get_index<'z'>(s) == s.template get<index_in<'z'>>());
 
 		int j =
-			+ sc.template get<index_in<'z'>>() * 30 * 20
-			+ sa.template get<index_in<'x'>>() * 30
-			+ sb.template get<index_in<'y'>>()
+			+ s.template get<index_in<'z'>>() * 30 * 20
+			+ s.template get<index_in<'x'>>() * 30
+			+ s.template get<index_in<'y'>>()
 		;
 
 		REQUIRE(i == j);
@@ -119,31 +107,19 @@ TEST_CASE("Traverser ordered", "[traverser]") {
 
 	int i = 0;
 
-	traverser(a, b, c).order(reorder<'x', 'y', 'z'>()).for_each([&i](auto sa, auto sb, auto sc){
-		static_assert( decltype(sa)::template contains<index_in<'x'>>);
-		static_assert( decltype(sa)::template contains<index_in<'y'>>);
-		static_assert(!decltype(sa)::template contains<index_in<'z'>>);
+	traverser(a, b, c).order(reorder<'x', 'y', 'z'>()).for_each([&i](auto s){
+		static_assert(decltype(s)::template contains<index_in<'x'>>);
+		static_assert(decltype(s)::template contains<index_in<'y'>>);
+		static_assert(decltype(s)::template contains<index_in<'z'>>);
 
-		static_assert(!decltype(sb)::template contains<index_in<'x'>>);
-		static_assert( decltype(sb)::template contains<index_in<'y'>>);
-		static_assert( decltype(sb)::template contains<index_in<'z'>>);
-
-		static_assert( decltype(sc)::template contains<index_in<'x'>>);
-		static_assert(!decltype(sc)::template contains<index_in<'y'>>);
-		static_assert( decltype(sc)::template contains<index_in<'z'>>);
-
-		REQUIRE(sa.template get<index_in<'x'>>() == sc.template get<index_in<'x'>>());
-		REQUIRE(sa.template get<index_in<'y'>>() == sb.template get<index_in<'y'>>());
-		REQUIRE(sb.template get<index_in<'z'>>() == sc.template get<index_in<'z'>>());
-
-		REQUIRE(sa.template get<index_in<'x'>>() < 20);
-		REQUIRE(sb.template get<index_in<'y'>>() < 30);
-		REQUIRE(sc.template get<index_in<'z'>>() < 40);
+		REQUIRE(s.template get<index_in<'x'>>() < 20);
+		REQUIRE(s.template get<index_in<'y'>>() < 30);
+		REQUIRE(s.template get<index_in<'z'>>() < 40);
 
 		int j =
-			+ sa.template get<index_in<'x'>>() * 30 * 40
-			+ sb.template get<index_in<'y'>>() * 40
-			+ sc.template get<index_in<'z'>>()
+			+ s.template get<index_in<'x'>>() * 30 * 40
+			+ s.template get<index_in<'y'>>() * 40
+			+ s.template get<index_in<'z'>>()
 		;
 
 		REQUIRE(i == j);
@@ -190,31 +166,19 @@ TEST_CASE("Traverser ordered renamed", "[traverser]") {
 
 	int i = 0;
 
-	traverser(a, b, c).order(reorder<'x', 'y', 'z'>() ^ noarr::rename<'y', 't'>()).for_each([&i](auto sa, auto sb, auto sc){
-		static_assert( decltype(sa)::template contains<index_in<'x'>>);
-		static_assert( decltype(sa)::template contains<index_in<'y'>>);
-		static_assert(!decltype(sa)::template contains<index_in<'z'>>);
+	traverser(a, b, c).order(reorder<'x', 'y', 'z'>() ^ noarr::rename<'y', 't'>()).for_each([&i](auto s){
+		static_assert(decltype(s)::template contains<index_in<'x'>>);
+		static_assert(decltype(s)::template contains<index_in<'y'>>);
+		static_assert(decltype(s)::template contains<index_in<'z'>>);
 
-		static_assert(!decltype(sb)::template contains<index_in<'x'>>);
-		static_assert( decltype(sb)::template contains<index_in<'y'>>);
-		static_assert( decltype(sb)::template contains<index_in<'z'>>);
-
-		static_assert( decltype(sc)::template contains<index_in<'x'>>);
-		static_assert(!decltype(sc)::template contains<index_in<'y'>>);
-		static_assert( decltype(sc)::template contains<index_in<'z'>>);
-		
-		REQUIRE(sa.template get<index_in<'x'>>() == sc.template get<index_in<'x'>>());
-		REQUIRE(sa.template get<index_in<'y'>>() == sb.template get<index_in<'y'>>());
-		REQUIRE(sb.template get<index_in<'z'>>() == sc.template get<index_in<'z'>>());
-
-		REQUIRE(sa.template get<index_in<'x'>>() < 20);
-		REQUIRE(sb.template get<index_in<'y'>>() < 30);
-		REQUIRE(sc.template get<index_in<'z'>>() < 40);
+		REQUIRE(s.template get<index_in<'x'>>() < 20);
+		REQUIRE(s.template get<index_in<'y'>>() < 30);
+		REQUIRE(s.template get<index_in<'z'>>() < 40);
 
 		int j =
-			+ sa.template get<index_in<'x'>>() * 30 * 40
-			+ sb.template get<index_in<'y'>>() * 40
-			+ sc.template get<index_in<'z'>>()
+			+ s.template get<index_in<'x'>>() * 30 * 40
+			+ s.template get<index_in<'y'>>() * 40
+			+ s.template get<index_in<'z'>>()
 		;
 
 		REQUIRE(i == j);
@@ -242,14 +206,14 @@ TEST_CASE("Traverser ordered renamed access", "[traverser]") {
 	bt b;
 	ct c;
 
-	traverser(a, b, c).order(reorder<'x', 'y', 'z'>() ^ noarr::rename<'y', 't'>()).for_each([&](auto sa, auto sb, auto sc){
-		REQUIRE((a | offset(sa)) / sizeof(int) == sa.template get<index_in<'x'>>() * 30 + sa.template get<index_in<'y'>>());
-		REQUIRE((b | offset(sb)) / sizeof(int) == sb.template get<index_in<'y'>>() * 40 + sb.template get<index_in<'z'>>());
-		REQUIRE((c | offset(sc)) / sizeof(int) == sc.template get<index_in<'x'>>() * 40 + sc.template get<index_in<'z'>>());
+	traverser(a, b, c).order(reorder<'x', 'y', 'z'>() ^ noarr::rename<'y', 't'>()).for_each([&](auto s){
+		REQUIRE((a | offset(s)) / sizeof(int) == s.template get<index_in<'x'>>() * 30 + s.template get<index_in<'y'>>());
+		REQUIRE((b | offset(s)) / sizeof(int) == s.template get<index_in<'y'>>() * 40 + s.template get<index_in<'z'>>());
+		REQUIRE((c | offset(s)) / sizeof(int) == s.template get<index_in<'x'>>() * 40 + s.template get<index_in<'z'>>());
 
-		REQUIRE((char*) &(a | get_at(ap, sa)) == (char*) ap + (a | offset(sa)));
-		REQUIRE((char*) &(b | get_at(bp, sb)) == (char*) bp + (b | offset(sb)));
-		REQUIRE((char*) &(c | get_at(cp, sc)) == (char*) cp + (c | offset(sc)));
+		REQUIRE((char*) &(a | get_at(ap, s)) == (char*) ap + (a | offset(s)));
+		REQUIRE((char*) &(b | get_at(bp, s)) == (char*) bp + (b | offset(s)));
+		REQUIRE((char*) &(c | get_at(cp, s)) == (char*) cp + (c | offset(s)));
 	});
 }
 
@@ -262,17 +226,12 @@ TEST_CASE("Traverser ordered renamed access blocked", "[traverser blocks]") {
 
 	std::size_t i = 0;
 
-	traverser(a, b).order(noarr::into_blocks<'x', 'u', 'v'>(4)).for_each([&](auto sa, auto sb){
-		REQUIRE(!decltype(sa)::template contains<index_in<'u'>> & !decltype(sa)::template contains<index_in<'v'>>);
-		REQUIRE(!decltype(sb)::template contains<index_in<'u'>> & !decltype(sb)::template contains<index_in<'v'>>);
-		REQUIRE( decltype(sa)::template contains<index_in<'x'>> &  decltype(sa)::template contains<index_in<'y'>>);
-		REQUIRE( decltype(sb)::template contains<index_in<'x'>> &  decltype(sb)::template contains<index_in<'y'>>);
+	traverser(a, b).order(noarr::into_blocks<'x', 'u', 'v'>(4)).for_each([&](auto s){
+		REQUIRE(!decltype(s)::template contains<index_in<'u'>> & !decltype(s)::template contains<index_in<'v'>>);
+		REQUIRE( decltype(s)::template contains<index_in<'x'>> &  decltype(s)::template contains<index_in<'y'>>);
 
-		REQUIRE(sa.template get<index_in<'x'>>() == sb.template get<index_in<'x'>>());
-		REQUIRE(sa.template get<index_in<'y'>>() == sb.template get<index_in<'y'>>());
-
-		std::size_t x = sa.template get<index_in<'x'>>();
-		std::size_t y = sa.template get<index_in<'y'>>();
+		std::size_t x = s.template get<index_in<'x'>>();
+		std::size_t y = s.template get<index_in<'y'>>();
 		REQUIRE(y*20 + x == i);
 		i++;
 	});
@@ -289,17 +248,12 @@ TEST_CASE("Traverser ordered renamed access strip mined", "[traverser shortcuts 
 
 	std::size_t i = 0;
 
-	traverser(a, b).order(noarr::strip_mine<'x', 'u', 'v'>(4)).for_each([&](auto sa, auto sb){
-		REQUIRE(!decltype(sa)::template contains<index_in<'u'>> & !decltype(sa)::template contains<index_in<'v'>>);
-		REQUIRE(!decltype(sb)::template contains<index_in<'u'>> & !decltype(sb)::template contains<index_in<'v'>>);
-		REQUIRE( decltype(sa)::template contains<index_in<'x'>> &  decltype(sa)::template contains<index_in<'y'>>);
-		REQUIRE( decltype(sb)::template contains<index_in<'x'>> &  decltype(sb)::template contains<index_in<'y'>>);
+	traverser(a, b).order(noarr::strip_mine<'x', 'u', 'v'>(4)).for_each([&](auto s){
+		REQUIRE(!decltype(s)::template contains<index_in<'u'>> & !decltype(s)::template contains<index_in<'v'>>);
+		REQUIRE( decltype(s)::template contains<index_in<'x'>> &  decltype(s)::template contains<index_in<'y'>>);
 
-		REQUIRE(sa.template get<index_in<'x'>>() == sb.template get<index_in<'x'>>());
-		REQUIRE(sa.template get<index_in<'y'>>() == sb.template get<index_in<'y'>>());
-
-		std::size_t x = sa.template get<index_in<'x'>>();
-		std::size_t y = sa.template get<index_in<'y'>>();
+		std::size_t x = s.template get<index_in<'x'>>();
+		std::size_t y = s.template get<index_in<'y'>>();
 		std::size_t u = x / 4;
 		std::size_t v = x % 4;
 		REQUIRE(u*30*4 + y*4 + v == i);
@@ -477,28 +431,16 @@ TEST_CASE("Traverser single state", "[traverser]") {
 	auto t = traverser(scalar<float>() ^ array<'x', 100>()).order(fix<'x'>(42));
 
 	auto s = t.state();
-	auto [s0] = t.states();
 
 	REQUIRE(get_index<'x'>(s) == 42);
-
-	REQUIRE(get_index<'x'>(s0) == 42);
 }
 
 TEST_CASE("Traverser single state multi struct", "[traverser]") {
 	auto t = traverser(scalar<float>() ^ array<'x', 100>() ^ array<'y', 200>(), scalar<float>() ^ array<'y', 200>() ^ array<'z', 300>()).order(fix<'x'>(42) ^ fix<'y'>(142) ^ fix<'z'>(242));
 
 	auto s = t.state();
-	auto [s0, s1] = t.states();
 
 	REQUIRE(get_index<'x'>(s) == 42);
 	REQUIRE(get_index<'y'>(s) == 142);
 	REQUIRE(get_index<'z'>(s) == 242);
-
-	REQUIRE(get_index<'x'>(s0) == 42);
-	REQUIRE(get_index<'y'>(s0) == 142);
-	REQUIRE(s0.template contains<index_in<'z'>> == false);
-
-	REQUIRE(s1.template contains<index_in<'x'>> == false);
-	REQUIRE(get_index<'y'>(s1) == 142);
-	REQUIRE(get_index<'z'>(s1) == 242);
 }


### PR DESCRIPTION
This allows us to simplify `traverser::for_each` lambdas to just one argument valid for all structures (one that contains all the indices), instead of one argument per structure (each restricted for one structure).